### PR TITLE
Fix quality profile update for Sonarr/Radarr

### DIFF
--- a/radarr.py
+++ b/radarr.py
@@ -290,6 +290,8 @@ class UpdateMovieRequest(BaseModel):
     minimumAvailability: Optional[str] = None
     tags: Optional[List[int]] = None
     rootFolderPath: Optional[str] = None
+    newRootFolderPath: Optional[str] = None
+    moveFiles: Optional[bool] = False
 class UpdateTagsRequest(BaseModel):
     tags: List[int] = Field(..., description="List of tag IDs to assign to the movie")
 
@@ -317,7 +319,7 @@ async def update_movie(movie_id: int, request: UpdateMovieRequest, instance: dic
     movie_data = await radarr_api_call(instance, f"movie/{movie_id}")
     update_fields = request.dict(exclude_unset=True)
     for key, value in update_fields.items():
-        if hasattr(movie_data, key):
+        if key in movie_data:
             movie_data[key] = value
             
     return await radarr_api_call(instance, "movie", method="PUT", json_data=movie_data)

--- a/sonarr.py
+++ b/sonarr.py
@@ -288,6 +288,8 @@ class UpdateSeriesRequest(BaseModel):
     seasonFolder: Optional[bool] = None
     path: Optional[str] = None
     tags: Optional[List[int]] = None
+    newRootFolderPath: Optional[str] = None
+    moveFiles: Optional[bool] = False
 
 class UpdateTagsRequest(BaseModel):
     tags: List[int] = Field(..., description="List of tag IDs to assign to the series")
@@ -425,7 +427,7 @@ async def update_series_properties(
     series_data = await sonarr_api_call(instance, f"series/{series_id}")
     update_fields = request.dict(exclude_unset=True)
     for key, value in update_fields.items():
-        if hasattr(series_data, key):
+        if key in series_data:
             series_data[key] = value
             
     return await sonarr_api_call(instance, f"series/{series_id}", method="PUT", json_data=series_data)


### PR DESCRIPTION
## Summary
- extend `UpdateSeriesRequest` and `UpdateMovieRequest` with `newRootFolderPath` and `moveFiles`
- correctly update dict data when applying series/movie changes

## Testing
- `python -m pip install -r requirements.txt`
- `python generate_openapi.py`
- `python -m py_compile sonarr.py radarr.py main.py instance_endpoints.py`

------
https://chatgpt.com/codex/tasks/task_e_687b1266eb4883259b76f792a6850cfd