### PR TITLE
Improve library search validation and pagination

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import os
 import json
-from fastapi import FastAPI, Depends, HTTPException, Request
+from fastapi import FastAPI, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from fastapi.openapi.utils import get_openapi


### PR DESCRIPTION
## Summary
- enforce minimum search term length
- use Radarr's pagination correctly
- keep in-app pagination for Sonarr
- remove unused imports and variables

## Testing
- `pip install -r requirements.txt`
- `python generate_openapi.py`
- `python -m py_compile radarr.py sonarr.py main.py instance_endpoints.py generate_openapi.py prune_openapi.py`


------
https://chatgpt.com/codex/tasks/task_e_687bef02b20083259d69dd277a4f584d