### PR TITLE
Improve Sonarr and Radarr search endpoints

### DIFF
--- a/sonarr.py
+++ b/sonarr.py
@@ -508,13 +508,23 @@ async def monitor_season(series_id: int, season_number: int, request: MonitorReq
     return updated_series
 
 
-@router.post("/series/{series_id}/fix", status_code=200, summary="Fix a series by replacing the current release", operation_id="fix_sonarr_release")
+@router.post(
+    "/series/{series_id}/fix",
+    status_code=200,
+    summary="Replace a damaged episode file",
+    operation_id="fix_sonarr_release",
+)
 async def fix_series_release(
     series_id: int,
     episode_id: int,
     instance: dict = Depends(get_sonarr_instance)
 ):
-    """Fixes a downloaded episode by deleting the file and triggering a new search. Requires episode_id from get_episodes."""
+    """Replace a corrupted or unwanted episode file.
+
+    The endpoint deletes the specified file and triggers a search for a new copy.
+    It should not be used as a general upgrade mechanism.
+    Requires ``episode_id`` from :func:`get_episodes`.
+    """
     # 1. Delete the file
     episode_files = await sonarr_api_call(instance, "episodefile", params={"seriesId": series_id})
     files_to_delete = [f["id"] for f in episode_files if episode_id in f.get("episodeIds", [])]
@@ -526,6 +536,52 @@ async def fix_series_release(
     await sonarr_api_call(instance, "command", method="POST", json_data={"name": "EpisodeSearch", "episodeIds": [episode_id]})
 
     return {"message": f"Successfully deleted the file for episode {episode_id} and triggered a new search."}
+
+
+@router.post(
+    "/series/{series_id}/episodes/{episode_id}/search",
+    status_code=200,
+    summary="Search for a single episode",
+    operation_id="search_sonarr_episode",
+)
+async def search_episode(
+    series_id: int,
+    episode_id: int,
+    instance: dict = Depends(get_sonarr_instance),
+):
+    """Trigger a search for an individual episode without deleting existing files."""
+
+    await sonarr_api_call(
+        instance,
+        "command",
+        method="POST",
+        json_data={"name": "EpisodeSearch", "episodeIds": [episode_id]},
+    )
+
+    return {"message": f"Triggered search for episode {episode_id}."}
+
+
+@router.post(
+    "/series/{series_id}/seasons/{season_number}/search",
+    status_code=200,
+    summary="Search for all episodes in a season",
+    operation_id="search_sonarr_season",
+)
+async def search_season(
+    series_id: int,
+    season_number: int,
+    instance: dict = Depends(get_sonarr_instance),
+):
+    """Trigger a search for every monitored episode in a season."""
+
+    await sonarr_api_call(
+        instance,
+        "command",
+        method="POST",
+        json_data={"name": "SeasonSearch", "seriesId": series_id, "seasonNumber": season_number},
+    )
+
+    return {"message": f"Triggered season search for season {season_number}."}
 
 
 @router.delete("/series/{series_id}", status_code=200, summary="Delete a series from Sonarr", operation_id="delete_sonarr_series")


### PR DESCRIPTION
## Summary
- avoid Radarr 500 errors by filtering movie search locally
- clarify that `fix` endpoints are for damaged files
- add episode and season level search endpoints for Sonarr

## Testing
- `python -m py_compile radarr.py sonarr.py`
- `pip install -r requirements.txt`
- `python generate_openapi.py`

------
https://chatgpt.com/codex/tasks/task_e_687d2c3014008325993a1c1dcc6b8466