### PR TITLE
Improve Radarr movie search pagination

### DIFF
--- a/radarr.py
+++ b/radarr.py
@@ -93,35 +93,61 @@ async def radarr_api_call(instance: dict, endpoint: str, method: str = "GET", pa
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Error communicating with Radarr: {str(e)}")
 
-@router.get("/library", response_model=List[Movie], summary="Check if a movie exists in the Radarr library", operation_id="find_radarr_movies")
+@router.get(
+    "/library",
+    response_model=List[Movie],
+    summary="Check if a movie exists in the Radarr library",
+    operation_id="find_radarr_movies",
+)
 async def find_movie_in_library(
     term: Optional[str] = Query(default=None, description="The search term to filter by."),
     page: int = Query(default=1, description="The page number to retrieve."),
     page_size: int = Query(default=25, description="The number of items per page."),
-    instance: dict = Depends(get_radarr_instance)
+    instance: dict = Depends(get_radarr_instance),
 ):
-    """Search the Radarr library with optional pagination."""
+    """Search the Radarr library with optional pagination.
 
-    if term is None or len(term.strip()) < 3:
-        raise HTTPException(status_code=400, detail="Search term must be at least 3 characters long.")
+    Radarr sometimes returns errors when filtering server-side. To avoid this we
+    fetch all movies and filter locally when a search term is provided.
+    """
 
-    params = {
-        "page": page,
-        "pageSize": page_size,
-        "term": term,
-    }
+    async def get_all_movies():
+        """Retrieve all movies from Radarr, handling pagination."""
+        movies = []
+        page = 1
+        page_size_param = 1000
+        while True:
+            resp = await radarr_api_call(
+                instance,
+                "movie",
+                params={"page": page, "pageSize": page_size_param},
+            )
+            page_movies = resp.get("records", resp) or []
+            movies.extend(page_movies)
 
-    response = await radarr_api_call(instance, "movie", params=params)
-    all_movies = response.get("records", response)
+            total = resp.get("totalRecords")
+            if total is None or len(movies) >= total:
+                break
+            page += 1
+        return movies
 
+    all_movies = await get_all_movies()
+
+    # Map quality profile IDs to names
     quality_profiles = await radarr_api_call(instance, "qualityprofile")
     quality_profile_map = {qp["id"]: qp["name"] for qp in quality_profiles}
 
+    filtered_movies = []
+    term_lower = term.lower() if term else None
     for m in all_movies:
-        if "qualityProfileId" in m:
-            m["qualityProfileName"] = quality_profile_map.get(m["qualityProfileId"], "Unknown")
+        if term_lower is None or term_lower in m.get("title", "").lower():
+            if "qualityProfileId" in m:
+                m["qualityProfileName"] = quality_profile_map.get(m["qualityProfileId"], "Unknown")
+            filtered_movies.append(m)
 
-    return all_movies
+    start_index = (page - 1) * page_size
+    end_index = start_index + page_size
+    return filtered_movies[start_index:end_index]
 
 @router.get("/search", summary="Search for a movie by term")
 async def search_movie(term: str, instance: dict = Depends(get_radarr_instance)):
@@ -446,9 +472,18 @@ async def monitor_movie(movie_id: int, request: MonitorRequest, instance: dict =
     return updated_movie
 
 
-@router.post("/movie/{movie_id}/fix", response_model=Movie, summary="Fix a movie by re-downloading it", operation_id="fix_radarr_movie")
+@router.post(
+    "/movie/{movie_id}/fix",
+    response_model=Movie,
+    summary="Replace a damaged movie file",
+    operation_id="fix_radarr_movie",
+)
 async def fix_movie(movie_id: int, instance: dict = Depends(get_radarr_instance)):
-    """Fixes a movie by deleting it, re-adding it, and triggering a new search."""
+    """Replace a corrupted or unwanted movie file.
+
+    This endpoint deletes the existing movie, re-adds it, and triggers a search
+    for a fresh copy. It should **not** be used for routine quality upgrades.
+    """
     # Get movie details to get the title
     try:
         movie = await radarr_api_call(instance, f"movie/{movie_id}")

--- a/sonarr.py
+++ b/sonarr.py
@@ -508,13 +508,23 @@ async def monitor_season(series_id: int, season_number: int, request: MonitorReq
     return updated_series
 
 
-@router.post("/series/{series_id}/fix", status_code=200, summary="Fix a series by replacing the current release", operation_id="fix_sonarr_release")
+@router.post(
+    "/series/{series_id}/fix",
+    status_code=200,
+    summary="Replace a damaged episode file",
+    operation_id="fix_sonarr_release",
+)
 async def fix_series_release(
     series_id: int,
     episode_id: int,
     instance: dict = Depends(get_sonarr_instance)
 ):
-    """Fixes a downloaded episode by deleting the file and triggering a new search. Requires episode_id from get_episodes."""
+    """Replace a corrupted or unwanted episode file.
+
+    The endpoint deletes the specified file and triggers a search for a new copy.
+    It should not be used as a general upgrade mechanism.
+    Requires ``episode_id`` from :func:`get_episodes`.
+    """
     # 1. Delete the file
     episode_files = await sonarr_api_call(instance, "episodefile", params={"seriesId": series_id})
     files_to_delete = [f["id"] for f in episode_files if episode_id in f.get("episodeIds", [])]
@@ -526,6 +536,52 @@ async def fix_series_release(
     await sonarr_api_call(instance, "command", method="POST", json_data={"name": "EpisodeSearch", "episodeIds": [episode_id]})
 
     return {"message": f"Successfully deleted the file for episode {episode_id} and triggered a new search."}
+
+
+@router.post(
+    "/series/{series_id}/episodes/{episode_id}/search",
+    status_code=200,
+    summary="Search for a single episode",
+    operation_id="search_sonarr_episode",
+)
+async def search_episode(
+    series_id: int,
+    episode_id: int,
+    instance: dict = Depends(get_sonarr_instance),
+):
+    """Trigger a search for an individual episode without deleting existing files."""
+
+    await sonarr_api_call(
+        instance,
+        "command",
+        method="POST",
+        json_data={"name": "EpisodeSearch", "episodeIds": [episode_id]},
+    )
+
+    return {"message": f"Triggered search for episode {episode_id}."}
+
+
+@router.post(
+    "/series/{series_id}/seasons/{season_number}/search",
+    status_code=200,
+    summary="Search for all episodes in a season",
+    operation_id="search_sonarr_season",
+)
+async def search_season(
+    series_id: int,
+    season_number: int,
+    instance: dict = Depends(get_sonarr_instance),
+):
+    """Trigger a search for every monitored episode in a season."""
+
+    await sonarr_api_call(
+        instance,
+        "command",
+        method="POST",
+        json_data={"name": "SeasonSearch", "seriesId": series_id, "seasonNumber": season_number},
+    )
+
+    return {"message": f"Triggered season search for season {season_number}."}
 
 
 @router.delete("/series/{series_id}", status_code=200, summary="Delete a series from Sonarr", operation_id="delete_sonarr_series")


### PR DESCRIPTION
## Summary
- handle Radarr library pagination when filtering movies locally
- clarify `fix` endpoint usage

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile radarr.py sonarr.py`
- `python generate_openapi.py`


------
https://chatgpt.com/codex/tasks/task_e_687d2c3014008325993a1c1dcc6b8466