### PR TITLE
Remove /search endpoints

### DIFF
--- a/radarr.py
+++ b/radarr.py
@@ -124,15 +124,6 @@ async def get_movie_id_by_title(title: str, instance: dict = Depends(get_radarr_
             return {"movie_id": m["id"]}
     raise HTTPException(status_code=404, detail=f"Movie with title '{title}' not found.")
 
-@router.get("/search", summary="Search for a movie by term")
-async def search_movie(term: str, instance: dict = Depends(get_radarr_instance)):
-    """Searches for a movie by term and returns the TMDB ID."""
-    try:
-        return await radarr_api_call(instance, "movie/lookup", params={"term": term})
-    except Exception as e:
-        print(f"Error in search_movie: {e}")
-        raise HTTPException(status_code=500, detail="Error searching for movie.")
-
 @router.get("/lookup", summary="Search for a new movie to add to Radarr")
 async def lookup_movie(term: str, instance: dict = Depends(get_radarr_instance)):
     """Searches for a new movie by a search term. This is the first step to add a new movie."""

--- a/sonarr.py
+++ b/sonarr.py
@@ -130,11 +130,6 @@ async def get_series_id_by_title(title: str, instance: dict = Depends(get_sonarr
             return {"series_id": s["id"]}
     raise HTTPException(status_code=404, detail=f"Series with title '{title}' not found.")
 
-@router.get("/search", summary="Search for a new series by term")
-async def search_series(term: str, instance: dict = Depends(get_sonarr_instance)):
-    """Searches for a new series by term and returns the TVDB ID."""
-    return await sonarr_api_call(instance, "series/lookup", params={"term": term})
-
 @router.get("/lookup", summary="Search for a new series to add to Sonarr")
 async def lookup_series(term: str, instance: dict = Depends(get_sonarr_instance)):
     """Searches for a new series by a search term. This is the first step to add a new series."""


### PR DESCRIPTION
## Summary
- drop unused search routes in radarr and sonarr

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68865f2ac01c8325b7012b18bbf92aac