### PR TITLE
Use shared httpx client

### DIFF
--- a/radarr.py
+++ b/radarr.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 import httpx
 import os
 from instance_endpoints import get_radarr_instance
+from main import get_http_client
 
 # Pydantic Models for Radarr
 class Movie(BaseModel):
@@ -61,47 +62,57 @@ router = APIRouter(
 
 
 
-async def radarr_api_call(instance: dict, endpoint: str, method: str = "GET", params: dict = None, json_data: dict = None):
+async def radarr_api_call(
+    instance: dict,
+    endpoint: str,
+    client: httpx.AsyncClient,
+    method: str = "GET",
+    params: dict = None,
+    json_data: dict = None,
+):
     """Make an API call to a specific Radarr instance."""
     headers = {"X-Api-Key": instance["api_key"], "Content-Type": "application/json"}
     url = f"{instance['url']}/api/v3/{endpoint}"
     print(f"Calling Radarr API: {method} {url} with params: {params}")
     
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        try:
-            if method == "GET":
-                response = await client.get(url, headers=headers, params=params)
-            elif method == "POST":
-                response = await client.post(url, headers=headers, json=json_data, params=params)
-            elif method == "PUT":
-                response = await client.put(url, headers=headers, json=json_data, params=params)
-            elif method == "DELETE":
-                response = await client.delete(url, headers=headers, params=params)
-            else:
-                raise HTTPException(status_code=405, detail="Method not allowed")
-            
-            print(f"Radarr API response: {response.status_code}")
-            response.raise_for_status()
-            
-            # Handle successful empty responses
-            if response.status_code == 204 or not response.text:
-                return None
-                
-            return response.json()
-        except httpx.HTTPStatusError as e:
-            raise HTTPException(status_code=e.response.status_code, detail=f"Radarr API error: {e.response.text}")
-        except httpx.RequestError as e:
-            raise HTTPException(status_code=502, detail=f"Error connecting to Radarr: {str(e)}.")
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Error communicating with Radarr: {str(e)}")
+    try:
+        if method == "GET":
+            response = await client.get(url, headers=headers, params=params)
+        elif method == "POST":
+            response = await client.post(url, headers=headers, json=json_data, params=params)
+        elif method == "PUT":
+            response = await client.put(url, headers=headers, json=json_data, params=params)
+        elif method == "DELETE":
+            response = await client.delete(url, headers=headers, params=params)
+        else:
+            raise HTTPException(status_code=405, detail="Method not allowed")
+
+        print(f"Radarr API response: {response.status_code}")
+        response.raise_for_status()
+
+        # Handle successful empty responses
+        if response.status_code == 204 or not response.text:
+            return None
+
+        return response.json()
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(status_code=e.response.status_code, detail=f"Radarr API error: {e.response.text}")
+    except httpx.RequestError as e:
+        raise HTTPException(status_code=502, detail=f"Error connecting to Radarr: {str(e)}.")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error communicating with Radarr: {str(e)}")
 
 @router.get("/library/movies", response_model=List[Movie], operation_id="search_radarr_library_for_movies", summary="Search Radarr library for movies.")
-async def find_movie_in_library(term: str, instance: dict = Depends(get_radarr_instance)):
+async def find_movie_in_library(
+    term: str,
+    instance: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Searches for a movie in the library. For user output, prefer 'find_movies_with_tags'."""
-    all_movies = await radarr_api_call(instance, "movie")
+    all_movies = await radarr_api_call(instance, "movie", client)
     
     # Get quality profiles to map IDs to names
-    quality_profiles = await radarr_api_call(instance, "qualityprofile")
+    quality_profiles = await radarr_api_call(instance, "qualityprofile", client)
     quality_profile_map = {qp["id"]: qp["name"] for qp in quality_profiles}
     
     # Filter movies and add quality profile name
@@ -116,24 +127,37 @@ async def find_movie_in_library(term: str, instance: dict = Depends(get_radarr_i
     return filtered_movies
 
 @router.get("/movie/id_lookup", summary="Get the movie ID for a given title.", operation_id="get_radarr_movie_id_by_title")
-async def get_movie_id_by_title(title: str, instance: dict = Depends(get_radarr_instance)):
+async def get_movie_id_by_title(
+    title: str,
+    instance: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Looks up a movie by title and returns its ID. Use this to get the movie_id for other operations."""
-    all_movies = await radarr_api_call(instance, "movie")
+    all_movies = await radarr_api_call(instance, "movie", client)
     for m in all_movies:
         if title.lower() == m.get("title", "").lower():
             return {"movie_id": m["id"]}
     raise HTTPException(status_code=404, detail=f"Movie with title '{title}' not found.")
 
 @router.get("/lookup", summary="Search for a new movie to add to Radarr")
-async def lookup_movie(term: str, instance: dict = Depends(get_radarr_instance)):
+async def lookup_movie(
+    term: str,
+    instance: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Searches for a new movie by a search term. This is the first step to add a new movie."""
     encoded_term = quote(term)
-    return await radarr_api_call(instance, f"movie/lookup?term={encoded_term}")
+    return await radarr_api_call(instance, f"movie/lookup?term={encoded_term}", client)
 
 @router.put("/movie/{movie_id}/move", response_model=ConfirmationMessage, summary="Move movie to new folder", tags=["internal-admin"])
-async def move_movie(movie_id: int, move_request: MoveMovieRequest, instance: dict = Depends(get_radarr_instance)):
+async def move_movie(
+    movie_id: int,
+    move_request: MoveMovieRequest,
+    instance: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Moves a movie to a new root folder and triggers Radarr to move the files."""
-    movie = await radarr_api_call(instance, f"movie/{movie_id}")
+    movie = await radarr_api_call(instance, f"movie/{movie_id}", client)
     
     # Radarr's move logic is different from Sonarr's.
     # It requires a separate "movie/editor" endpoint.
@@ -144,7 +168,7 @@ async def move_movie(movie_id: int, move_request: MoveMovieRequest, instance: di
         }
     
     # We need to get the ID of the destination root folder.
-    root_folders = await radarr_api_call(instance, "rootfolder")
+    root_folders = await radarr_api_call(instance, "rootfolder", client)
     target_folder = next((rf for rf in root_folders if rf["path"] == move_request.rootFolderPath), None)
     
     if not target_folder:
@@ -153,7 +177,7 @@ async def move_movie(movie_id: int, move_request: MoveMovieRequest, instance: di
     move_payload["targetRootFolderId"] = target_folder["id"]
 
     # This is a command, not a simple PUT on the movie object
-    await radarr_api_call(instance, "movie/editor", method="PUT", json_data=move_payload)
+    await radarr_api_call(instance, "movie/editor", client, method="PUT", json_data=move_payload)
     
     # Return a confirmation message
     return {"message": f"Move command initiated for movie {movie_id}."}
@@ -166,11 +190,15 @@ class AddMovieRequest(BaseModel):
     searchForMovie: bool = True
 
 @router.post("/movie", response_model=Movie, summary="Add a new movie to Radarr")
-async def add_movie(request: AddMovieRequest, instance: dict = Depends(get_radarr_instance)):
+async def add_movie(
+    request: AddMovieRequest,
+    instance: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Adds a new movie to Radarr by looking it up via its TMDB ID."""
     # First, lookup the movie by TMDB ID
     try:
-        movie_to_add = await radarr_api_call(instance, f"movie/lookup/tmdb?tmdbid={request.tmdbId}")
+        movie_to_add = await radarr_api_call(instance, f"movie/lookup/tmdb?tmdbid={request.tmdbId}", client)
         if not movie_to_add:
             raise HTTPException(status_code=404, detail=f"Movie with TMDB ID {request.tmdbId} not found.")
     except Exception as e:
@@ -184,7 +212,7 @@ async def add_movie(request: AddMovieRequest, instance: dict = Depends(get_radar
         raise HTTPException(status_code=400, detail="rootFolderPath must be provided either in the request or as an environment variable.")
 
     # Get quality profiles to find the ID for the given name
-    quality_profiles = await radarr_api_call(instance, "qualityprofile")
+    quality_profiles = await radarr_api_call(instance, "qualityprofile", client)
     quality_profile_id = None
     if request.qualityProfileId:
         quality_profile_id = request.qualityProfileId
@@ -208,15 +236,19 @@ async def add_movie(request: AddMovieRequest, instance: dict = Depends(get_radar
     }
 
     # Add the movie to Radarr
-    added_movie = await radarr_api_call(instance, "movie", method="POST", json_data=add_payload)
+    added_movie = await radarr_api_call(instance, "movie", client, method="POST", json_data=add_payload)
     return added_movie
 
 @router.post("/radarr/add_by_title", response_model=Movie, summary="Add a new movie to Radarr by title", operation_id="add_movie_by_title_radarr", tags=["internal-admin"])
-async def add_movie_by_title_radarr(title: str, instance: dict = Depends(get_radarr_instance)):
+async def add_movie_by_title_radarr(
+    title: str,
+    instance: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Adds a new movie to Radarr by looking it up by title."""
     # First, lookup the movie by title
     try:
-        lookup_results = await radarr_api_call(instance, "movie/lookup", params={"term": title})
+        lookup_results = await radarr_api_call(instance, "movie/lookup", client, params={"term": title})
         if not lookup_results:
             raise HTTPException(status_code=404, detail=f"Movie with title '{title}' not found.")
     except Exception as e:
@@ -236,7 +268,7 @@ async def add_movie_by_title_radarr(title: str, instance: dict = Depends(get_rad
         raise HTTPException(status_code=400, detail="rootFolderPath must be provided either in the request or as an environment variable.")
 
     # Get quality profiles to find the ID for the given name
-    quality_profiles = await radarr_api_call(instance, "qualityprofile")
+    quality_profiles = await radarr_api_call(instance, "qualityprofile", client)
     quality_profile_id = None
     if quality_profile_name:
         for profile in quality_profiles:
@@ -258,28 +290,39 @@ async def add_movie_by_title_radarr(title: str, instance: dict = Depends(get_rad
     }
 
     # Add the movie to Radarr
-    added_movie = await radarr_api_call(instance, "movie", method="POST", json_data=add_payload)
+    added_movie = await radarr_api_call(instance, "movie", client, method="POST", json_data=add_payload)
     return added_movie
 
 @router.get("/queue", response_model=List[QueueItem], summary="Get Radarr download queue")
-async def get_download_queue(instance: dict = Depends(get_radarr_instance)):
+async def get_download_queue(
+    instance: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Gets the list of items currently being downloaded by Radarr."""
-    queue_data = await radarr_api_call(instance, "queue")
+    queue_data = await radarr_api_call(instance, "queue", client)
     # The actual queue items are in the 'records' key
     return queue_data.get("records", [])
 
 @router.get("/history", response_model=List[HistoryItem], summary="Get Radarr download history")
-async def get_download_history(instance: dict = Depends(get_radarr_instance)):
+async def get_download_history(
+    instance: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Gets the history of recently grabbed and imported downloads from Radarr."""
-    history_data = await radarr_api_call(instance, "history")
+    history_data = await radarr_api_call(instance, "history", client)
     # The actual history items are in the 'records' key
     return history_data.get("records", [])
 
 @router.delete("/queue/{queue_id}", status_code=204, summary="Delete item from Radarr queue", operation_id="delete_radarr_queue_item")
-async def delete_from_queue(queue_id: int, removeFromClient: bool = True, instance: dict = Depends(get_radarr_instance)):
+async def delete_from_queue(
+    queue_id: int,
+    removeFromClient: bool = True,
+    instance: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Deletes an item from the Radarr download queue."""
     params = {"removeFromClient": str(removeFromClient).lower()}
-    await radarr_api_call(instance, f"queue/{queue_id}", method="DELETE", params=params)
+    await radarr_api_call(instance, f"queue/{queue_id}", client, method="DELETE", params=params)
     return
 
 class QualityProfile(BaseModel):
@@ -302,7 +345,12 @@ class MonitorRequest(BaseModel):
     monitored: bool
 
 @router.put("/movie/{movie_id}", operation_id="update_radarr_movie_properties", summary="Update movie properties")
-async def update_movie(movie_id: int, request: UpdateMovieRequest, instance: dict = Depends(get_radarr_instance)):
+async def update_movie(
+    movie_id: int,
+    request: UpdateMovieRequest,
+    instance: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Updates movie properties. To remove a tag, get the movie's current tags, then submit a new list of tags that excludes the one to be removed. This replaces the entire list of tags for the movie."""
     # If a new root folder is provided, handle the move operation.
     if request.newRootFolderPath:
@@ -311,42 +359,47 @@ async def update_movie(movie_id: int, request: UpdateMovieRequest, instance: dic
             "rootFolderPath": request.newRootFolderPath,
             "moveFiles": request.moveFiles,
         }
-        root_folders = await radarr_api_call(instance, "rootfolder")
+        root_folders = await radarr_api_call(instance, "rootfolder", client)
         target_folder = next((rf for rf in root_folders if rf["path"] == request.newRootFolderPath), None)
         if not target_folder:
             raise HTTPException(status_code=400, detail=f"Root folder '{request.newRootFolderPath}' not found in Radarr.")
         move_payload["targetRootFolderId"] = target_folder["id"]
-        return await radarr_api_call(instance, "movie/editor", method="PUT", json_data=move_payload)
+        return await radarr_api_call(instance, "movie/editor", client, method="PUT", json_data=move_payload)
 
     # Otherwise, perform a standard update.
-    movie_data = await radarr_api_call(instance, f"movie/{movie_id}")
+    movie_data = await radarr_api_call(instance, f"movie/{movie_id}", client)
     update_fields = request.dict(exclude_unset=True)
     for key, value in update_fields.items():
         if key in movie_data:
             movie_data[key] = value
             
-    return await radarr_api_call(instance, "movie", method="PUT", json_data=movie_data)
+    return await radarr_api_call(instance, "movie", client, method="PUT", json_data=movie_data)
 
 @router.get("/qualityprofiles", response_model=List[QualityProfile], summary="Get quality profiles for movies in Radarr")
-async def get_quality_profiles(instance: dict = Depends(get_radarr_instance)):
+async def get_quality_profiles(
+    instance: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Retrieves quality profiles for MOVIES configured in Radarr."""
-    return await radarr_api_call(instance, "qualityprofile")
+    return await radarr_api_call(instance, "qualityprofile", client)
 
 # Tag endpoints for Radarr following API v3 spec
 
 @router.get("/rootfolders", operation_id="get_radarr_rootfolders", summary="Get root folders from Radarr")
-async def get_root_folders(instance: dict = Depends(get_radarr_instance)):
+async def get_root_folders(
+    instance: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Get all configured root folders in Radarr."""
-    return await radarr_api_call(instance, "rootfolder")
+    return await radarr_api_call(instance, "rootfolder", client)
 
 # Helper function to get tag map
-async def get_tag_map(instance_config: dict) -> dict:
+async def get_tag_map(instance_config: dict, client: httpx.AsyncClient) -> dict:
     """Get a mapping of tag IDs to tag names."""
     url = f"{instance_config['url']}/api/v3/tag"
     headers = {"X-Api-Key": instance_config["api_key"]}
     
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.get(url, headers=headers)
+    response = await client.get(url, headers=headers)
     
     if response.status_code != 200:
         return {}
@@ -358,13 +411,13 @@ async def get_tag_map(instance_config: dict) -> dict:
 @router.get("/radarr/tags", summary="Get all tags from Radarr", operation_id="radarr_get_tags")
 async def get_tags(
     instance_config: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
 ):
     """Get all tags configured in Radarr."""
     url = f"{instance_config['url']}/api/v3/tag"
     headers = {"X-Api-Key": instance_config["api_key"]}
     
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.get(url, headers=headers)
+    response = await client.get(url, headers=headers)
     
     if response.status_code != 200:
         raise HTTPException(
@@ -378,14 +431,14 @@ async def get_tags(
 async def create_tag(
     label: str,
     instance_config: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
 ):
     """Create a new tag in Radarr."""
     url = f"{instance_config['url']}/api/v3/tag"
     headers = {"X-Api-Key": instance_config["api_key"]}
     payload = {"label": label}
     
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.post(url, json=payload, headers=headers)
+    response = await client.post(url, json=payload, headers=headers)
     
     if response.status_code != 201:
         raise HTTPException(
@@ -396,11 +449,16 @@ async def create_tag(
     return response.json()
 
 @router.put("/movie/{movie_id}/monitor", status_code=200, summary="Update monitoring status for a movie", operation_id="monitor_radarr_movie", tags=["internal-admin"])
-async def monitor_movie(movie_id: int, request: MonitorRequest, instance: dict = Depends(get_radarr_instance)):
+async def monitor_movie(
+    movie_id: int,
+    request: MonitorRequest,
+    instance: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Updates the monitoring status for a movie."""
-    movie_data = await radarr_api_call(instance, f"movie/{movie_id}")
+    movie_data = await radarr_api_call(instance, f"movie/{movie_id}", client)
     movie_data["monitored"] = request.monitored
-    updated_movie = await radarr_api_call(instance, "movie", method="PUT", json_data=movie_data)
+    updated_movie = await radarr_api_call(instance, "movie", client, method="PUT", json_data=movie_data)
     return updated_movie
 
 
@@ -409,11 +467,16 @@ async def monitor_movie(movie_id: int, request: MonitorRequest, instance: dict =
     summary="Search for a movie upgrade",
     operation_id="search_for_movie_upgrade",
 )
-async def search_for_movie_upgrade(movie_id: int, instance: dict = Depends(get_radarr_instance)):
+async def search_for_movie_upgrade(
+    movie_id: int,
+    instance: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Triggers a search for a movie to find a better quality version. This is a non-destructive action."""
     await radarr_api_call(
         instance,
         "command",
+        client,
         method="POST",
         json_data={"name": "MovieSearch", "movieIds": [movie_id]},
     )
@@ -421,11 +484,15 @@ async def search_for_movie_upgrade(movie_id: int, instance: dict = Depends(get_r
 
 
 @router.post("/movie/{movie_id}/fix", response_model=Movie, summary="Replace a damaged movie file", operation_id="fix_radarr_movie")
-async def fix_movie(movie_id: int, instance: dict = Depends(get_radarr_instance)):
+async def fix_movie(
+    movie_id: int,
+    instance: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Deletes, re-adds, and searches for a movie. WARNING: This is a destructive action. For routine quality upgrades, use the '/movie/{movie_id}/search' endpoint instead."""
     # Get movie details to get the title
     try:
-        movie = await radarr_api_call(instance, f"movie/{movie_id}")
+        movie = await radarr_api_call(instance, f"movie/{movie_id}", client)
         title_to_add = movie["title"]
     except HTTPException as e:
         if e.status_code == 404:
@@ -433,10 +500,10 @@ async def fix_movie(movie_id: int, instance: dict = Depends(get_radarr_instance)
         raise e
 
     # Delete the movie
-    await delete_movie(movie_id, deleteFiles=True, addImportExclusion=False, instance=instance)
+    await delete_movie(movie_id, deleteFiles=True, addImportExclusion=False, instance=instance, client=client)
 
     # Re-add the movie by title
-    added_movie = await add_movie_by_title_radarr(title_to_add, instance)
+    added_movie = await add_movie_by_title_radarr(title_to_add, instance, client)
     return added_movie
 
 @router.delete("/movie/{movie_id}", status_code=200, summary="Delete a movie from Radarr", operation_id="delete_radarr_movie")
@@ -444,12 +511,13 @@ async def delete_movie(
     movie_id: int,
     deleteFiles: bool = True,
     addImportExclusion: bool = False,
-    instance: dict = Depends(get_radarr_instance)
+    instance: dict = Depends(get_radarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
 ):
     """Deletes a movie from Radarr. To re-download, you must re-add the movie."""
     params = {
         "deleteFiles": str(deleteFiles).lower(),
         "addImportExclusion": str(addImportExclusion).lower()
     }
-    await radarr_api_call(instance, f"movie/{movie_id}", method="DELETE", params=params)
+    await radarr_api_call(instance, f"movie/{movie_id}", client, method="DELETE", params=params)
     return {"message": f"Movie with ID {movie_id} has been deleted."}

--- a/sonarr.py
+++ b/sonarr.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 import httpx
 import os
 from instance_endpoints import get_sonarr_instance
+from main import get_http_client
 
 # Pydantic Models for Sonarr
 class Series(BaseModel):
@@ -56,35 +57,41 @@ router = APIRouter(
     tags=["sonarr"],
 )
 
-async def sonarr_api_call(instance: dict, endpoint: str, method: str = "GET", params: dict = None, json_data: dict = None):
+async def sonarr_api_call(
+    instance: dict,
+    endpoint: str,
+    client: httpx.AsyncClient,
+    method: str = "GET",
+    params: dict = None,
+    json_data: dict = None,
+):
     """Make an API call to a specific Sonarr instance."""
     headers = {"X-Api-Key": instance["api_key"], "Content-Type": "application/json"}
     url = f"{instance['url']}/api/v3/{endpoint}"
     
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        try:
-            if method == "GET":
-                response = await client.get(url, headers=headers, params=params)
-            elif method == "POST":
-                response = await client.post(url, headers=headers, json=json_data, params=params)
-            elif method == "PUT":
-                response = await client.put(url, headers=headers, json=json_data, params=params)
-            elif method == "DELETE":
-                response = await client.delete(url, headers=headers, params=params)
-            else:
-                raise HTTPException(status_code=405, detail="Method not allowed")
-            
-            response.raise_for_status()
-            # For DELETE requests that return no content
-            if response.status_code == 204 or not response.text:
-                return None
-            return response.json()
-        except httpx.HTTPStatusError as e:
-            raise HTTPException(status_code=e.response.status_code, detail=f"Sonarr API error: {e.response.text}")
-        except httpx.RequestError as e:
-            raise HTTPException(status_code=502, detail=f"Error connecting to Sonarr: {str(e)}.")
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Error communicating with Sonarr: {str(e)}")
+    try:
+        if method == "GET":
+            response = await client.get(url, headers=headers, params=params)
+        elif method == "POST":
+            response = await client.post(url, headers=headers, json=json_data, params=params)
+        elif method == "PUT":
+            response = await client.put(url, headers=headers, json=json_data, params=params)
+        elif method == "DELETE":
+            response = await client.delete(url, headers=headers, params=params)
+        else:
+            raise HTTPException(status_code=405, detail="Method not allowed")
+
+        response.raise_for_status()
+        # For DELETE requests that return no content
+        if response.status_code == 204 or not response.text:
+            return None
+        return response.json()
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(status_code=e.response.status_code, detail=f"Sonarr API error: {e.response.text}")
+    except httpx.RequestError as e:
+        raise HTTPException(status_code=502, detail=f"Error connecting to Sonarr: {str(e)}.")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error communicating with Sonarr: {str(e)}")
 
 class Episode(BaseModel):
     id: int
@@ -97,17 +104,25 @@ class Episode(BaseModel):
     monitored: bool
 
 @router.get("/series/{series_id}/episodes", response_model=List[Episode], summary="Get all episodes for a series", operation_id="get_sonarr_episodes")
-async def get_episodes(series_id: int, instance: dict = Depends(get_sonarr_instance)):
+async def get_episodes(
+    series_id: int,
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Retrieves all episodes for a given series."""
-    return await sonarr_api_call(instance, "episode", params={"seriesId": series_id})
+    return await sonarr_api_call(instance, "episode", client, params={"seriesId": series_id})
 
 @router.get("/library/series", response_model=List[Series], operation_id="search_sonarr_library_for_series", summary="Search Sonarr library for series.")
-async def find_series_in_library(term: str, instance: dict = Depends(get_sonarr_instance)):
+async def find_series_in_library(
+    term: str,
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Searches for a series in the library. For user output, prefer 'find_series_with_tags'."""
-    all_series = await sonarr_api_call(instance, "series")
+    all_series = await sonarr_api_call(instance, "series", client)
     
     # Get quality profiles to map IDs to names
-    quality_profiles = await sonarr_api_call(instance, "qualityprofile")
+    quality_profiles = await sonarr_api_call(instance, "qualityprofile", client)
     quality_profile_map = {qp["id"]: qp["name"] for qp in quality_profiles}
     
     # Filter series and add quality profile name
@@ -122,23 +137,36 @@ async def find_series_in_library(term: str, instance: dict = Depends(get_sonarr_
     return filtered_series
 
 @router.get("/series/id_lookup", summary="Get the series ID for a given title.", operation_id="get_sonarr_series_id_by_title")
-async def get_series_id_by_title(title: str, instance: dict = Depends(get_sonarr_instance)):
+async def get_series_id_by_title(
+    title: str,
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Looks up a series by title and returns its ID. Use this to get the series_id for other operations."""
-    all_series = await sonarr_api_call(instance, "series")
+    all_series = await sonarr_api_call(instance, "series", client)
     for s in all_series:
         if title.lower() == s.get("title", "").lower():
             return {"series_id": s["id"]}
     raise HTTPException(status_code=404, detail=f"Series with title '{title}' not found.")
 
 @router.get("/lookup", summary="Search for a new series to add to Sonarr")
-async def lookup_series(term: str, instance: dict = Depends(get_sonarr_instance)):
+async def lookup_series(
+    term: str,
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Searches for a new series by a search term. This is the first step to add a new series."""
-    return await sonarr_api_call(instance, "series/lookup", params={"term": term})
+    return await sonarr_api_call(instance, "series/lookup", client, params={"term": term})
 
 @router.put("/series/{sonarr_id}/move", response_model=Series, summary="Move series to new folder", tags=["internal-admin"])
-async def move_series(sonarr_id: int, move_request: MoveSeriesRequest, instance: dict = Depends(get_sonarr_instance)):
+async def move_series(
+    sonarr_id: int,
+    move_request: MoveSeriesRequest,
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Moves a series to a new root folder and triggers Sonarr to move the files."""
-    series = await sonarr_api_call(instance, f"series/{sonarr_id}")
+    series = await sonarr_api_call(instance, f"series/{sonarr_id}", client)
     series_folder_name = os.path.basename(series["path"])
     new_path = os.path.join(move_request.rootFolderPath, series_folder_name)
     
@@ -146,7 +174,7 @@ async def move_series(sonarr_id: int, move_request: MoveSeriesRequest, instance:
     series["path"] = new_path
     series["moveFiles"] = True
     
-    updated_series = await sonarr_api_call(instance, f"series/{series['id']}", method="PUT", json_data=series)
+    updated_series = await sonarr_api_call(instance, f"series/{series['id']}", client, method="PUT", json_data=series)
     return updated_series
 
 class AddSeriesRequest(BaseModel):
@@ -157,11 +185,15 @@ class AddSeriesRequest(BaseModel):
     rootFolderPath: Optional[str] = None
 
 @router.post("/series", response_model=Series, summary="Add a new series to Sonarr")
-async def add_series(request: AddSeriesRequest, instance: dict = Depends(get_sonarr_instance)):
+async def add_series(
+    request: AddSeriesRequest,
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Adds a new series to Sonarr by looking it up via its TVDB ID."""
     # First, lookup the series by TVDB ID
     try:
-        series_to_add = await sonarr_api_call(instance, f"series/lookup?term=tvdb:{request.tvdbId}")
+        series_to_add = await sonarr_api_call(instance, f"series/lookup?term=tvdb:{request.tvdbId}", client)
         if not series_to_add:
             raise HTTPException(status_code=404, detail=f"Series with TVDB ID {request.tvdbId} not found.")
     except Exception as e:
@@ -176,7 +208,7 @@ async def add_series(request: AddSeriesRequest, instance: dict = Depends(get_son
         raise HTTPException(status_code=400, detail="rootFolderPath must be provided either in the request or as an environment variable.")
 
     # Get quality profiles to find the ID for the given name
-    quality_profiles = await sonarr_api_call(instance, "qualityprofile")
+    quality_profiles = await sonarr_api_call(instance, "qualityprofile", client)
     quality_profile_id = None
     if request.qualityProfileId:
         quality_profile_id = request.qualityProfileId
@@ -202,15 +234,19 @@ async def add_series(request: AddSeriesRequest, instance: dict = Depends(get_son
     }
 
     # Add the series to Sonarr
-    added_series = await sonarr_api_call(instance, "series", method="POST", json_data=add_payload)
+    added_series = await sonarr_api_call(instance, "series", client, method="POST", json_data=add_payload)
     return added_series
 
 @router.post("/sonarr/add_by_title", response_model=Series, summary="Add a new series to Sonarr by title", operation_id="add_series_by_title_sonarr", tags=["internal-admin"])
-async def add_series_by_title_sonarr(title: str, instance: dict = Depends(get_sonarr_instance)):
+async def add_series_by_title_sonarr(
+    title: str,
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Adds a new series to Sonarr by looking it up by title."""
     # First, lookup the series by title
     try:
-        lookup_results = await sonarr_api_call(instance, "series/lookup", params={"term": title})
+        lookup_results = await sonarr_api_call(instance, "series/lookup", client, params={"term": title})
         if not lookup_results:
             raise HTTPException(status_code=404, detail=f"Series with title '{title}' not found.")
     except Exception as e:
@@ -231,7 +267,7 @@ async def add_series_by_title_sonarr(title: str, instance: dict = Depends(get_so
         raise HTTPException(status_code=400, detail="rootFolderPath must be provided either in the request or as an environment variable.")
 
     # Get quality profiles to find the ID for the given name
-    quality_profiles = await sonarr_api_call(instance, "qualityprofile")
+    quality_profiles = await sonarr_api_call(instance, "qualityprofile", client)
     quality_profile_id = None
     if quality_profile_name:
         for profile in quality_profiles:
@@ -255,28 +291,39 @@ async def add_series_by_title_sonarr(title: str, instance: dict = Depends(get_so
     }
 
     # Add the series to Sonarr
-    added_series = await sonarr_api_call(instance, "series", method="POST", json_data=add_payload)
+    added_series = await sonarr_api_call(instance, "series", client, method="POST", json_data=add_payload)
     return added_series
 
 @router.get("/queue", response_model=List[QueueItem], summary="Get Sonarr download queue")
-async def get_download_queue(instance: dict = Depends(get_sonarr_instance)):
+async def get_download_queue(
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Gets the list of items currently being downloaded by Sonarr."""
-    queue_data = await sonarr_api_call(instance, "queue")
+    queue_data = await sonarr_api_call(instance, "queue", client)
     # The actual queue items are in the 'records' key
     return queue_data.get("records", [])
 
 @router.get("/history", response_model=List[HistoryItem], summary="Get Sonarr download history")
-async def get_download_history(instance: dict = Depends(get_sonarr_instance)):
+async def get_download_history(
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Gets the history of recently grabbed and imported downloads from Sonarr."""
-    history_data = await sonarr_api_call(instance, "history")
+    history_data = await sonarr_api_call(instance, "history", client)
     # The actual history items are in the 'records' key
     return history_data.get("records", [])
 
 @router.delete("/queue/{queue_id}", status_code=204, summary="Delete item from Sonarr queue", operation_id="delete_sonarr_queue_item")
-async def delete_from_queue(queue_id: int, removeFromClient: bool = True, instance: dict = Depends(get_sonarr_instance)):
+async def delete_from_queue(
+    queue_id: int,
+    removeFromClient: bool = True,
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Deletes an item from the Sonarr download queue."""
     params = {"removeFromClient": str(removeFromClient).lower()}
-    await sonarr_api_call(instance, f"queue/{queue_id}", method="DELETE", params=params)
+    await sonarr_api_call(instance, f"queue/{queue_id}", client, method="DELETE", params=params)
     return
 
 class QualityProfile(BaseModel):
@@ -304,19 +351,21 @@ class MonitorRequest(BaseModel):
     monitored: bool
 
 @router.get("/qualityprofiles", response_model=List[QualityProfile], summary="Get quality profiles for TV SHOWS in Sonarr")
-async def get_quality_profiles(instance: dict = Depends(get_sonarr_instance)):
+async def get_quality_profiles(
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Retrieves quality profiles for TV SHOWS configured in Sonarr."""
-    return await sonarr_api_call(instance, "qualityprofile")
+    return await sonarr_api_call(instance, "qualityprofile", client)
 
 
 # Helper function to get tag map
-async def get_tag_map(instance_config: dict) -> dict:
+async def get_tag_map(instance_config: dict, client: httpx.AsyncClient) -> dict:
     """Get a mapping of tag IDs to tag names."""
     url = f"{instance_config['url']}/api/v3/tag"
     headers = {"X-Api-Key": instance_config["api_key"]}
     
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.get(url, headers=headers)
+    response = await client.get(url, headers=headers)
     
     if response.status_code != 200:
         return {}
@@ -326,10 +375,14 @@ async def get_tag_map(instance_config: dict) -> dict:
 
 # Update the library search to include tag names
 @router.get("/library/with-tags", summary="Find TV SHOW with tag names", operation_id="series_with_tags")
-async def find_series_with_tags(term: str, instance: dict = Depends(get_sonarr_instance)):
+async def find_series_with_tags(
+    term: str,
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Searches library and includes tag names instead of just IDs. Use this for user-facing output."""
-    all_series = await sonarr_api_call(instance, "series")
-    tag_map = await get_tag_map(instance)
+    all_series = await sonarr_api_call(instance, "series", client)
+    tag_map = await get_tag_map(instance, client)
     
     filtered_series = []
     for s in all_series:
@@ -347,13 +400,13 @@ async def find_series_with_tags(term: str, instance: dict = Depends(get_sonarr_i
 @router.get("/sonarr/tags", summary="Get all tags from Sonarr", operation_id="sonarr_get_tags")
 async def get_tags(
     instance_config: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
 ):
     """Get all tags configured in Sonarr."""
     url = f"{instance_config['url']}/api/v3/tag"
     headers = {"X-Api-Key": instance_config["api_key"]}
     
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.get(url, headers=headers)
+    response = await client.get(url, headers=headers)
     
     if response.status_code != 200:
         raise HTTPException(
@@ -367,14 +420,14 @@ async def get_tags(
 async def create_tag(
     label: str,
     instance_config: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
 ):
     """Create a new tag in Sonarr."""
     url = f"{instance_config['url']}/api/v3/tag"
     headers = {"X-Api-Key": instance_config["api_key"]}
     payload = {"label": label}
     
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.post(url, json=payload, headers=headers)
+    response = await client.post(url, json=payload, headers=headers)
     
     if response.status_code != 201:
         raise HTTPException(
@@ -388,38 +441,37 @@ async def create_tag(
 async def delete_tag(
     tag_id: int,
     instance_config: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
 ):
     """Delete a tag from Sonarr by its ID."""
     url = f"{instance_config['url']}/api/v3/tag/{tag_id}"
     headers = {"X-Api-Key": instance_config["api_key"]}
     
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.delete(url, headers=headers)
-        
-        if response.status_code == 404:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Tag with ID {tag_id} not found"
-            )
-        elif response.status_code != 200 and response.status_code != 204:
-            raise HTTPException(
-                status_code=response.status_code,
-                detail=f"Failed to delete tag: {response.text}"
-            )
-        
-        return
+    response = await client.delete(url, headers=headers)
+    if response.status_code == 404:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Tag with ID {tag_id} not found",
+        )
+    elif response.status_code != 200 and response.status_code != 204:
+        raise HTTPException(
+            status_code=response.status_code,
+            detail=f"Failed to delete tag: {response.text}"
+        )
+
 
 
 @router.put("/series/{series_id}", operation_id="update_sonarr_series_properties", summary="Update series properties")
 async def update_series_properties(
     series_id: int,
     request: UpdateSeriesRequest,
-    instance: dict = Depends(get_sonarr_instance)
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
 ):
     """Updates series properties. To remove a tag, get the series's current tags, then submit a new list of tags that excludes the one to be removed. This replaces the entire list of tags for the series."""
     # If a new root folder is provided, handle the move operation.
     if request.newRootFolderPath:
-        series = await sonarr_api_call(instance, f"series/{series_id}")
+        series = await sonarr_api_call(instance, f"series/{series_id}", client)
         series_folder_name = os.path.basename(series["path"])
         new_path = os.path.join(request.newRootFolderPath, series_folder_name)
         
@@ -427,28 +479,33 @@ async def update_series_properties(
         series["path"] = new_path
         series["moveFiles"] = request.moveFiles
         
-        return await sonarr_api_call(instance, f"series/{series['id']}", method="PUT", json_data=series)
+        return await sonarr_api_call(instance, f"series/{series['id']}", client, method="PUT", json_data=series)
 
     # Otherwise, perform a standard update.
-    series_data = await sonarr_api_call(instance, f"series/{series_id}")
+    series_data = await sonarr_api_call(instance, f"series/{series_id}", client)
     update_fields = request.dict(exclude_unset=True)
     for key, value in update_fields.items():
         if key in series_data:
             series_data[key] = value
             
-    return await sonarr_api_call(instance, f"series/{series_id}", method="PUT", json_data=series_data)
+    return await sonarr_api_call(instance, f"series/{series_id}", client, method="PUT", json_data=series_data)
 
 @router.put("/series/{series_id}/monitor", status_code=200, summary="Update monitoring status for an entire series", operation_id="monitor_sonarr_series", tags=["internal-admin"])
-async def monitor_series(series_id: int, request: MonitorRequest, instance: dict = Depends(get_sonarr_instance)):
+async def monitor_series(
+    series_id: int,
+    request: MonitorRequest,
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Updates the monitoring status for an entire series."""
-    series_data = await sonarr_api_call(instance, f"series/{series_id}")
+    series_data = await sonarr_api_call(instance, f"series/{series_id}", client)
     series_data["monitored"] = request.monitored
     
     # Cascade the monitoring status to all seasons
     for season in series_data.get("seasons", []):
         season["monitored"] = request.monitored
         
-    updated_series = await sonarr_api_call(instance, f"series/{series_id}", method="PUT", json_data=series_data)
+    updated_series = await sonarr_api_call(instance, f"series/{series_id}", client, method="PUT", json_data=series_data)
     return updated_series
 
 @router.post(
@@ -456,20 +513,31 @@ async def monitor_series(series_id: int, request: MonitorRequest, instance: dict
     summary="Search for a series upgrade",
     operation_id="search_for_series_upgrade",
 )
-async def search_for_series_upgrade(series_id: int, instance: dict = Depends(get_sonarr_instance)):
+async def search_for_series_upgrade(
+    series_id: int,
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Triggers a search for a series to find a better quality version. This is a non-destructive action."""
     await sonarr_api_call(
         instance,
         "command",
+        client,
         method="POST",
         json_data={"name": "SeriesSearch", "seriesId": series_id},
     )
     return {"message": f"Triggered search for series {series_id}."}
 
 @router.put("/series/{series_id}/seasons/{season_number}/monitor", status_code=200, summary="Update monitoring status for a single season", operation_id="monitor_sonarr_season", tags=["internal-admin"])
-async def monitor_season(series_id: int, season_number: int, request: MonitorRequest, instance: dict = Depends(get_sonarr_instance)):
+async def monitor_season(
+    series_id: int,
+    season_number: int,
+    request: MonitorRequest,
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Updates the monitoring status for a single season of a series."""
-    series_data = await sonarr_api_call(instance, f"series/{series_id}")
+    series_data = await sonarr_api_call(instance, f"series/{series_id}", client)
     
     # Find the season and update its monitored status
     season_found = False
@@ -482,7 +550,7 @@ async def monitor_season(series_id: int, season_number: int, request: MonitorReq
     if not season_found:
         raise HTTPException(status_code=404, detail=f"Season {season_number} not found in series {series_id}")
 
-    updated_series = await sonarr_api_call(instance, f"series/{series_id}", method="PUT", json_data=series_data)
+    updated_series = await sonarr_api_call(instance, f"series/{series_id}", client, method="PUT", json_data=series_data)
     return updated_series
 
 
@@ -496,12 +564,14 @@ async def search_episode(
     series_id: int,
     episode_id: int,
     instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
 ):
     """Trigger a search for an individual episode without deleting existing files."""
 
     await sonarr_api_call(
         instance,
         "command",
+        client,
         method="POST",
         json_data={"name": "EpisodeSearch", "episodeIds": [episode_id]},
     )
@@ -510,11 +580,15 @@ async def search_episode(
 
 
 @router.post("/series/{series_id}/fix", response_model=Series, summary="Replace a damaged series", operation_id="fix_sonarr_series")
-async def fix_series(series_id: int, instance: dict = Depends(get_sonarr_instance)):
+async def fix_series(
+    series_id: int,
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Deletes, re-adds, and searches for a series. WARNING: This is a destructive action. For routine quality upgrades, use the '/series/{series_id}/search' endpoint instead."""
     # Get series details to get the title
     try:
-        series = await sonarr_api_call(instance, f"series/{series_id}")
+        series = await sonarr_api_call(instance, f"series/{series_id}", client)
         title_to_add = series["title"]
     except HTTPException as e:
         if e.status_code == 404:
@@ -522,19 +596,25 @@ async def fix_series(series_id: int, instance: dict = Depends(get_sonarr_instanc
         raise e
 
     # Delete the series
-    await delete_series(series_id, deleteFiles=True, addImportExclusion=False, instance=instance)
+    await delete_series(series_id, deleteFiles=True, addImportExclusion=False, instance=instance, client=client)
 
     # Re-add the series by title
-    added_series = await add_series_by_title_sonarr(title_to_add, instance)
+    added_series = await add_series_by_title_sonarr(title_to_add, instance, client)
     return added_series
 
 
 @router.post("/series/{series_id}/season/{season_number}/search", status_code=200, summary="Trigger a search for an entire season", operation_id="season_search")
-async def search_season(series_id: int, season_number: int, instance: dict = Depends(get_sonarr_instance)):
+async def search_season(
+    series_id: int,
+    season_number: int,
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Triggers a search for all episodes within a season."""
     await sonarr_api_call(
         instance,
         "command",
+        client,
         method="POST",
         json_data={"name": "SeasonSearch", "seriesId": series_id, "seasonNumber": season_number},
     )
@@ -542,11 +622,16 @@ async def search_season(series_id: int, season_number: int, instance: dict = Dep
 
 
 @router.post("/series/{series_id}/search", status_code=200, summary="Trigger a search for an entire series", operation_id="series_search")
-async def search_series(series_id: int, instance: dict = Depends(get_sonarr_instance)):
+async def search_series(
+    series_id: int,
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client),
+):
     """Triggers a search for all episodes of a series."""
     await sonarr_api_call(
         instance,
         "command",
+        client,
         method="POST",
         json_data={"name": "SeriesSearch", "seriesId": series_id},
     )
@@ -558,14 +643,15 @@ async def delete_series(
     series_id: int,
     deleteFiles: bool = True,
     addImportExclusion: bool = False,
-    instance: dict = Depends(get_sonarr_instance)
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client)
 ):
     """Deletes a whole series."""
     params = {
         "deleteFiles": str(deleteFiles).lower(),
         "addImportListExclusion": str(addImportExclusion).lower()
     }
-    await sonarr_api_call(instance, f"series/{series_id}", method="DELETE", params=params)
+    await sonarr_api_call(instance, f"series/{series_id}", client, method="DELETE", params=params)
     return {"message": f"Series with ID {series_id} has been deleted."}
 
 @router.delete("/series/{series_id}/episodes", status_code=200, summary="Delete a specific episode file from Sonarr", operation_id="delete_sonarr_episode")
@@ -573,11 +659,12 @@ async def delete_episode(
     series_id: int,
     season_number: int,
     episode_number: int,
-    instance: dict = Depends(get_sonarr_instance)
+    instance: dict = Depends(get_sonarr_instance),
+    client: httpx.AsyncClient = Depends(get_http_client)
 ):
     """Deletes a specific episode file."""
     # Find the episode_id
-    episodes = await sonarr_api_call(instance, "episode", params={"seriesId": series_id})
+    episodes = await sonarr_api_call(instance, "episode", client, params={"seriesId": series_id})
     episode_to_delete = None
     for episode in episodes:
         if episode.get("seasonNumber") == season_number and episode.get("episodeNumber") == episode_number:
@@ -590,7 +677,7 @@ async def delete_episode(
     # Delete the episode file
     episode_file_id = episode_to_delete.get("episodeFileId")
     if episode_file_id:
-        await sonarr_api_call(instance, f"episodefile/{episode_file_id}", method="DELETE")
+        await sonarr_api_call(instance, f"episodefile/{episode_file_id}", client, method="DELETE")
         return {"message": f"Successfully deleted file for episode S{season_number:02d}E{episode_number:02d}."}
     else:
         raise HTTPException(status_code=404, detail="Episode file ID not found.")


### PR DESCRIPTION
## Summary
- create a single AsyncClient on startup and close it on shutdown
- expose `get_http_client` dependency
- refactor Radarr and Sonarr routes to receive the shared client

## Testing
- `python -m py_compile sonarr.py radarr.py main.py`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6888e66d0374832591be2cc90b493554