### PR TITLE
Restore per-request client usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,36 @@
-<div align="center">
+<img width="1310" height="1626" alt="vivaldi_oSan3uImz1" src="https://github.com/user-attachments/assets/6e8ea6cf-f0f7-43ac-8f65-ea7d62567bf0" />
+                                  
+# Toolarr: Sonarr & Radarr API Bridge for AI
 
-  <h1>Toolarr: A Stateless API Bridge for Sonarr & Radarr</h1>
-  <p>
-    <strong>A high-performance, privacy-focused, and AI-native API server that connects AI assistants like Open WebUI and ChatGPT to your Sonarr and Radarr instances for seamless media management.</strong>
-  </p>
-  <p>
-    <a href="#overview">Overview</a> •
-    <a href="#key-features">Key Features</a> •
-    <a href="#ai-integration">AI Integration</a> •
-    <a href="#getting-started">Getting Started</a> •
-    <a href="#example-prompts">Example Prompts</a>
-  </p>
-</div>
+Toolarr exposes a clean, tool-friendly API that allows AI assistants (like Open WebUI) to manage your Sonarr and Radarr media libraries using natural language. The server maintains a single shared HTTP connection pool for all requests, improving performance when talking to your *arr instances.
 
-Toolarr is engineered to be a lightweight and efficient pass-through API bridge, addressing the common performance and privacy issues found in other media management tools. It provides a clean, unified interface for all your Sonarr and Radarr instances without retaining any state or logging user data.
 
-Its core design principle is statelessness; instance configurations are loaded from environment variables on-demand for each request, ensuring minimal overhead and maximum speed.
+##  Connect to Open WebUI
 
-***
+1. In Open WebUI, go to **Settings > Tools** and click **Add Tool**.
+2. Enter the OpenAPI schema URL: `http://<your-docker-host-ip>:8000`
+3. Set the authentication type to **Bearer Token** and enter your `TOOL_API_KEY`.
 
-### Overview
+##  Features
 
--   **High-Performance and Stateless:** I made this because the *arr MPC servers I have tried were fun, but were slow, clunky, and tended to overrun context of an LLM quickly. I wanted something I could tie into my voice assistant, so it needed to be more focused in its API calls
+- **Unified API**: Manage multiple Sonarr and Radarr instances through a single, consistent interface.
+- **Library Management**: Search for media, view quality profiles, move content, and update monitoring status.
+- **Media Management**: Add and delete movies and TV shows, including their files.
+- **Tagging**: Create, view, assign, and delete tags.
+- **Queue Control**: View download queues and history, and remove items from the queue.
 
--   **Optimized for AI:** Toolarr is not just compatible with AI; it's designed for it. It generates a specially pruned OpenAPI schema to work flawlessly within the constraints of custom GPTs and other AI tools.
--   **Unified Multi-Instance Support:** Manage any number of Sonarr and Radarr servers through a single, consistent API interface.
--   **Secure by Default:** All API endpoints are protected by Bearer Token authentication, and your underlying Sonarr/Radarr API keys are never exposed in responses.
--   **Simple Docker Deployment:** Deploys as a lightweight, multi-stage Docker container for a fast and simple setup.
+## 💬 Example Prompts
 
-***
+- "What quality profile is assigned to The Matrix?"
+- "Show me the Sonarr download queue."
+- "Find all movies with the '4K' quality profile."
+- "Delete the stuck download for Breaking Bad."
 
-### Key Features
+## 🔒 Security
 
-Toolarr provides a comprehensive suite of endpoints for robust media management.
+- All endpoints require Bearer token authentication.
+- Your Sonarr/Radarr API keys are never exposed in responses.
 
--   **Media Management:** Add new movies and TV shows via title or ID (TMDb/TVDb), and delete existing media, including the underlying files.
--   **Library Updates:** Modify monitoring status, change quality profiles, update paths, and move media files to new root folders.
--   **Intelligent Search:** Trigger searches for missing media, specific seasons, or non-destructive quality upgrades.
--   **System & Library Information:** Perform library-wide searches, retrieve detailed media information with quality profiles, and get a list of all configured root folders.
--   **Tagging:** Full support for listing, creating, assigning, and removing tags from your media.
--   **Download Queue Management:** View the current download queue and history, and remove stuck or unwanted items directly.
+## 📄 License
 
-***
-
-### AI Integration
-
-A key feature of Toolarr is its built-in OpenAPI schema generator, which creates two distinct specification files during the build process.
-
-1.  `openapi.json`: The full, comprehensive API specification for use with tools like Open WebUI.
-2.  `openapi-chatgpt.json`: A pruned specification file designed explicitly for AI models with endpoint limitations. This version automatically excludes all endpoints tagged as "internal-admin," ensuring it respects the **30-endpoint limit** for tools in platforms like OpenAI's custom GPTs. This makes Toolarr an ideal backend for creating powerful, custom "Media Manager" GPTs.
-
-***
-
-### Getting Started
-
-Deployment is handled via Docker and requires minimal configuration.
-
-1.  **Configure Environment:** Copy `.env.example` to `.env` and populate it with your instance URLs and API keys.
-    ```bash
-    cp .env.example .env
-    nano .env
-    ```
-
-2.  **Launch Service:** Use the provided `docker-compose.yml` to build and run the service.
-    ```bash
-    docker-compose up -d
-    ```
-<<<<<<< HEAD
-    The container automatically generates `openapi.json` and `openapi-chatgpt.json` on startup. If you need to regenerate them later, run:
-=======
-    The container generates `openapi.json` and `openapi-chatgpt.json` during the Docker build and again each time it starts. If you ever need to regenerate them manually, run:
->>>>>>> b6c12e3 (Regenerate OpenAPI during build and startup)
-    ```bash
-    python generate_openapi.py
-    ```
-
-3.  **Connect to AI Assistant:**
-    -   **Open WebUI:** Navigate to **Settings > Tools** and select **Add Tool**.
-    -   **Custom GPT (ChatGPT):** Create a new GPT, go to **Configure > Actions > Add an action**, and choose "Import from URL."
-    -   **Schema URL:**
-        -   For full functionality (e.g., Open WebUI): `http://<your-docker-host-ip>:8000/openapi.json`
-        -   For ChatGPT or other limited platforms: `http://<your-docker-host-ip>:8000/openapi-chatgpt.json`
-    -   **Authentication:** Set the authentication method to **Bearer Token** and provide the `TOOL_API_KEY` from your `.env` file.
-
-### Example Prompts
-
--   "In Radarr, search for the movie 'Dune: Part Two'."
--   "Add the TV show 'Fallout' to Sonarr and search for missing episodes."
--   "What's currently in the Sonarr download queue?"
--   "Delete the movie 'The Emoji Movie' from the default Radarr instance, and also delete the files."
--   "Find all movies in my library with the '4K' quality profile."
--   "Trigger an upgrade search for 'Oppenheimer'."
--   "The series 'Loki' appears to be having issues. Run the fix command for it on the Sonarr instance."
-
-***Note:*** This exposes endpoints that can delete your files, and should be respected as such. In the future I plan to add env vars to limit which endpoints can be used
-### License
-
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/radarr.py
+++ b/radarr.py
@@ -66,39 +66,35 @@ async def radarr_api_call(
     endpoint: str,
     request: Request,
     method: str = "GET",
-    params: dict = None,
-    json_data: dict = None,
-):
+    params: dict | None = None,
+    json_data: dict | None = None,
+) -> dict | None:
     """Make an API call to a specific Radarr instance."""
+    base_url = instance["url"].rstrip("/")
+    path = endpoint.lstrip("/")
+    url = f"{base_url}/api/v3/{path}"
     headers = {"X-Api-Key": instance["api_key"], "Content-Type": "application/json"}
-    url = f"{instance['url']}/api/v3/{endpoint}"
-    print(f"Calling Radarr API: {method} {url} with params: {params}")
 
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
-            if method == "GET":
-                response = await client.get(url, headers=headers, params=params)
-            elif method == "POST":
-                response = await client.post(url, headers=headers, json=json_data, params=params)
-            elif method == "PUT":
-                response = await client.put(url, headers=headers, json=json_data, params=params)
-            elif method == "DELETE":
-                response = await client.delete(url, headers=headers, params=params)
-            else:
-                raise HTTPException(status_code=405, detail="Method not allowed")
+            response = await client.request(
+                method,
+                url,
+                params=params,
+                json=json_data,
+                headers=headers,
+            )
 
-            print(f"Radarr API response: {response.status_code}")
-            response.raise_for_status()
+        response.raise_for_status()
 
-            # Handle successful empty responses
-            if response.status_code == 204 or not response.text:
-                return None
+        if response.status_code == 204 or not response.text:
+            return None
 
-            return response.json()
+        return response.json()
     except httpx.HTTPStatusError as e:
         raise HTTPException(status_code=e.response.status_code, detail=f"Radarr API error: {e.response.text}")
     except httpx.RequestError as e:
-        raise HTTPException(status_code=502, detail=f"Error connecting to Radarr: {str(e)}.")
+        raise HTTPException(status_code=502, detail=f"Error connecting to Radarr: {str(e)}")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error communicating with Radarr: {str(e)}")
 

--- a/sonarr.py
+++ b/sonarr.py
@@ -61,35 +61,33 @@ async def sonarr_api_call(
     endpoint: str,
     request: Request,
     method: str = "GET",
-    params: dict = None,
-    json_data: dict = None,
-):
+    params: dict | None = None,
+    json_data: dict | None = None,
+) -> dict | None:
     """Make an API call to a specific Sonarr instance."""
+    base_url = instance["url"].rstrip("/")
+    path = endpoint.lstrip("/")
+    url = f"{base_url}/api/v3/{path}"
     headers = {"X-Api-Key": instance["api_key"], "Content-Type": "application/json"}
-    url = f"{instance['url']}/api/v3/{endpoint}"
 
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
-            if method == "GET":
-                response = await client.get(url, headers=headers, params=params)
-            elif method == "POST":
-                response = await client.post(url, headers=headers, json=json_data, params=params)
-            elif method == "PUT":
-                response = await client.put(url, headers=headers, json=json_data, params=params)
-            elif method == "DELETE":
-                response = await client.delete(url, headers=headers, params=params)
-            else:
-                raise HTTPException(status_code=405, detail="Method not allowed")
+            response = await client.request(
+                method,
+                url,
+                params=params,
+                json=json_data,
+                headers=headers,
+            )
 
-            response.raise_for_status()
-            # For DELETE requests that return no content
-            if response.status_code == 204 or not response.text:
-                return None
-            return response.json()
+        response.raise_for_status()
+        if response.status_code == 204 or not response.text:
+            return None
+        return response.json()
     except httpx.HTTPStatusError as e:
         raise HTTPException(status_code=e.response.status_code, detail=f"Sonarr API error: {e.response.text}")
     except httpx.RequestError as e:
-        raise HTTPException(status_code=502, detail=f"Error connecting to Sonarr: {str(e)}.")
+        raise HTTPException(status_code=502, detail=f"Error connecting to Sonarr: {str(e)}")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error communicating with Sonarr: {str(e)}")
 


### PR DESCRIPTION
## Summary
- revert to creating a new HTTP client for every Radarr/Sonarr request
- keep improved URL handling while removing shared client usage

## Testing
- `pip install -r requirements.txt`
- `python generate_openapi.py`
- `python -m compileall .`


------
https://chatgpt.com/codex/tasks/task_e_688943c0b0a883259b0183cb2cf804ba